### PR TITLE
Fix class name typos

### DIFF
--- a/src/components/home/MyServices.tsx
+++ b/src/components/home/MyServices.tsx
@@ -55,7 +55,7 @@ export default function MyServices() {
             How can I help you
           </h2>
         </div>
-        <div className="border-stone-00 flex flex-col items-start justify-start gap-8 self-stretch">
+        <div className="flex flex-col items-start justify-start gap-8 self-stretch">
           <div className="flex flex-col gap-4">
             {services.map((service, index) => (
               <ServiceCard

--- a/src/components/shared/NavLink.tsx
+++ b/src/components/shared/NavLink.tsx
@@ -19,7 +19,7 @@ export default function NavLink({ href, children }: NavLinkProps) {
       className={`rounded-lg px-4 py-2 transition-colors duration-200 ${
         isActive
           ? "bg-blue-100 font-medium text-blue-600 md:bg-transparent"
-          : "text-stone-60 md:hover:text-blue-500"
+          : "text-stone-600 md:hover:text-blue-500"
       }`}
     >
       {children}

--- a/src/components/writings/ArticleCard.tsx
+++ b/src/components/writings/ArticleCard.tsx
@@ -16,7 +16,7 @@ export default function ArticleCard({ post }: ArticleCardProps) {
   });
 
   return (
-    <div className="ransition-shadow mb-8 overflow-hidden">
+    <div className="transition-shadow mb-8 overflow-hidden">
       <Link href={`/writings/${slug}`} className="block">
         <div className="rounded-lg">
           <p className="mb-2 text-sm text-gray-500">{formattedDate}</p>


### PR DESCRIPTION
## Summary
- fix typo in NavLink color class
- remove invalid class on MyServices container
- correct typo on ArticleCard

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849bf08a02c83279339096718cda306